### PR TITLE
Fix clang-format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,11 @@ dkms.conf
 
 # rebar3
 _build
+
+# clang-format
+run-clang-format
+
+# others
+build
+doc
+venv

--- a/nifs/atomvm_m5.cc
+++ b/nifs/atomvm_m5.cc
@@ -25,7 +25,7 @@
 #include <memory.h>
 #include <nifs.h>
 #include <term.h>
-//#define ENABLE_TRACE
+// #define ENABLE_TRACE
 #include <trace.h>
 
 #define MODULE_PREFIX "m5:"

--- a/nifs/atomvm_m5_btn.cc
+++ b/nifs/atomvm_m5_btn.cc
@@ -25,7 +25,7 @@
 #include <memory.h>
 #include <nifs.h>
 #include <term.h>
-//#define ENABLE_TRACE
+// #define ENABLE_TRACE
 #include <trace.h>
 
 #include "atomvm_m5_nifs.h"

--- a/nifs/atomvm_m5_imu.cc
+++ b/nifs/atomvm_m5_imu.cc
@@ -25,7 +25,7 @@
 #include <memory.h>
 #include <nifs.h>
 #include <term.h>
-//#define ENABLE_TRACE
+// #define ENABLE_TRACE
 #include <trace.h>
 
 #include "atomvm_m5_nifs.h"

--- a/nifs/atomvm_m5_power.cc
+++ b/nifs/atomvm_m5_power.cc
@@ -25,7 +25,7 @@
 #include <memory.h>
 #include <nifs.h>
 #include <term.h>
-//#define ENABLE_TRACE
+// #define ENABLE_TRACE
 #include <trace.h>
 
 #define MODULE_PREFIX "m5_power:"

--- a/nifs/atomvm_m5_power_axp192.cc
+++ b/nifs/atomvm_m5_power_axp192.cc
@@ -25,7 +25,7 @@
 #include <memory.h>
 #include <nifs.h>
 #include <term.h>
-//#define ENABLE_TRACE
+// #define ENABLE_TRACE
 #include <trace.h>
 
 #define MODULE_PREFIX "m5_power_axp192:"

--- a/nifs/atomvm_m5_rtc.cc
+++ b/nifs/atomvm_m5_rtc.cc
@@ -25,7 +25,7 @@
 #include <memory.h>
 #include <nifs.h>
 #include <term.h>
-//#define ENABLE_TRACE
+// #define ENABLE_TRACE
 #include <trace.h>
 
 #include "atomvm_m5_nifs.h"

--- a/nifs/atomvm_m5_speaker.cc
+++ b/nifs/atomvm_m5_speaker.cc
@@ -25,7 +25,7 @@
 #include <memory.h>
 #include <nifs.h>
 #include <term.h>
-//#define ENABLE_TRACE
+// #define ENABLE_TRACE
 #include <trace.h>
 
 #include "atomvm_m5_nifs.h"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `.gitignore` to ignore build, documentation, and virtual environment directories, as well as clang-format workflow files.

* **Style**
  * Applied consistent comment formatting across multiple project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->