### PR TITLE
Support IDF-SDK from 5.1 to 5.5, update CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,27 +8,37 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: espressif/idf:release-v5.2
+    container: espressif/idf:${{ matrix.idf-version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        esp-idf-target: ["esp32", "esp32c3", "esp32c6", "esp32s3", "esp32p4"]
+        language: ['cpp']
+        idf-version:
+         - 'v5.1.6'
+         - 'v5.2.6'
+         - 'v5.3.4'
+         - 'v5.4.3'
+         - 'v5.5.1'
+
+        exclude:
+        - esp-idf-target: "esp32c3"
+          idf-version: 'v5.1.6'
+        - esp-idf-target: "esp32p4"
+          idf-version: 'v5.1.6'
+        - esp-idf-target: "esp32p4"
+          idf-version: 'v5.2.6'
     steps:
     - name: Checkout AtomVM
       uses: actions/checkout@v5
       with:
         repository: atomvm/AtomVM
         path: AtomVM
-    - name: Checkout M5Unified
-      uses: actions/checkout@v5
-      with:
-        repository: m5stack/M5Unified
-        path: AtomVM/src/platform/esp32/components/
-    - name: Checkout M5GFX
-      uses: actions/checkout@v5
-      with:
-        repository: m5stack/M5GFX
-        path: AtomVM/src/platform/esp32/components/
     - name: Checkout atomvm_m5
       uses: actions/checkout@v5
       with:
-        path: AtomVM/src/platform/esp32/components/
+        path: AtomVM/src/platforms/esp32/components/atomvm_m5
+
     - name: Build with idf.py
       shell: bash
       working-directory: AtomVM/src/platforms/esp32/
@@ -39,7 +49,7 @@ jobs:
 
   build-doc:
     runs-on: ubuntu-latest
-    container: erlang:27
+    container: erlang:28
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -71,7 +81,7 @@ jobs:
 
   erlfmt:
     runs-on: ubuntu-latest
-    container: erlang:27
+    container: erlang:28
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@ This project is a port of M5Unified for the AtomVM platform.
 
 ## Installation
 
-- Install ESP-IDF SDK 5.2
+- Install ESP-IDF SDK 5.1 to 5.5 (5.5 recommended)
 - Checkout [atomvm](https://github.com/AtomVM/AtomVM)
-- Within `src/platform/esp32/components`, checkout [M5Unified](https://github.com/m5stack/M5Unified)
-- Within `src/platform/esp32/components`, checkout [M5GFX](https://github.com/m5stack/M5GFX)
 - Within `src/platform/esp32/components`, checkout this project
 - Activate ESP-IDF environment and within `src/platform/esp32/` run `idf.py build`
 
 ## Usage
 
 Please refer to [examples](examples/) and [API documentation](https://pguyot.github.io/atomvm_m5/).
+
+## M5Unified and M5GFX components
+
+This port is based on the following versions of M5Unified/M5GFX:
+- M5Unified [0.2.10](https://github.com/m5stack/M5Unified/releases/tag/0.2.10)
+- M5GFX [0.2.17](https://github.com/m5stack/M5GFX/releases/tag/0.2.17)

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,11 @@
+# Copyright 2025 Paul Guyot <pguyot@kallisys.net>
+# SPDX-License-Identifier: MIT
+dependencies:
+  idf:
+    version: '>=5.1.0'
+  M5Unified:
+    git: https://github.com/m5stack/M5Unified
+    version: 0.2.10
+  M5GFX:
+    git: https://github.com/m5stack/M5GFX
+    version: 0.2.17

--- a/nifs/atomvm_m5.cc
+++ b/nifs/atomvm_m5.cc
@@ -98,8 +98,8 @@ static term nif_get_board(Context* ctx, int argc, term argv[])
         return MAKE_ATOM(ctx, "\x5", "tough");
     case m5::board_t::board_M5Station:
         return MAKE_ATOM(ctx, "\x7", "station");
-    case m5::board_t::board_M5Atom:
-        return MAKE_ATOM(ctx, "\x4", "atom");
+    case m5::board_t::board_M5AtomLite:
+        return MAKE_ATOM(ctx, "\x9", "atom_lite");
     case m5::board_t::board_M5AtomPsram:
         return MAKE_ATOM(ctx, "\xA", "atom_psram");
     case m5::board_t::board_M5AtomU:

--- a/nifs/atomvm_m5_power.cc
+++ b/nifs/atomvm_m5_power.cc
@@ -123,6 +123,9 @@ static term nif_power_get_type(Context* ctx, int argc, term argv[])
     case m5::Power_Class::pmic_adc:
         result = MAKE_ATOM(ctx, "\x3", "adc");
         break;
+    case m5::Power_Class::pmic_aw32001:
+        result = MAKE_ATOM(ctx, "\x7", "aw32001");
+        break;
     case m5::Power_Class::pmic_axp192:
         result = MAKE_ATOM(ctx, "\x6", "axp192");
         break;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added M5AtomLite board detection.
  * Added support for AW32001 power management IC.
  * Broadened ESP‑IDF support to versions 5.1–5.5 (5.5 recommended).

* **Documentation**
  * Updated installation steps for ESP‑IDF range and added component version notes for M5Unified (0.2.10) and M5GFX (0.2.17).

* **Chores**
  * Expanded CI to run matrixed builds across ESP32 targets and IDF versions, updated build runtimes, and added a component manifest for dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->