### PR TITLE
Add v5.1 idf for esp32c3 as it should work

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         esp-idf-target: ["esp32", "esp32c3", "esp32c6", "esp32s3", "esp32p4"]
-        language: ['cpp']
         idf-version:
          - 'v5.1.6'
          - 'v5.2.6'
@@ -22,8 +21,6 @@ jobs:
          - 'v5.5.1'
 
         exclude:
-        - esp-idf-target: "esp32c3"
-          idf-version: 'v5.1.6'
         - esp-idf-target: "esp32p4"
           idf-version: 'v5.1.6'
         - esp-idf-target: "esp32p4"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded continuous integration testing to support additional ESP-IDF versions (v5.3.4, v5.4.3, v5.5.1) and improved build compatibility for esp32c3 target across more version combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->