### PR TITLE
Stick to M5GFX 0.2.16 for i2c driver compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ Please refer to [examples](examples/) and [API documentation](https://pguyot.git
 
 This port is based on the following versions of M5Unified/M5GFX:
 - M5Unified [0.2.10](https://github.com/m5stack/M5Unified/releases/tag/0.2.10)
-- M5GFX [0.2.17](https://github.com/m5stack/M5GFX/releases/tag/0.2.17)
+- M5GFX [0.2.16](https://github.com/m5stack/M5GFX/releases/tag/0.2.16) (0.2.17 is currently incompatible with AtomVM)

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -8,4 +8,4 @@ dependencies:
     version: 0.2.10
   M5GFX:
     git: https://github.com/m5stack/M5GFX
-    version: 0.2.17
+    version: 0.2.16


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated M5GFX dependency to resolve incompatibility with AtomVM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->