### PR TITLE
ex_how_to_use: add pythonx dependency for better esptool experience

### DIFF
--- a/examples/basic/ex_how_to_use/mix.exs
+++ b/examples/basic/ex_how_to_use/mix.exs
@@ -45,7 +45,8 @@ defmodule HowToUse.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:exatomvm, git: "https://github.com/atomvm/ExAtomVM/"},
+      {:exatomvm, git: "https://github.com/atomvm/ExAtomVM/", runtime: false},
+      {:pythonx, "~> 0.4.0", runtime: false, optional: true},
       {:atomvm_m5, path: "../../../"}
     ]
   end

--- a/examples/basic/ex_how_to_use/mix.lock
+++ b/examples/basic/ex_how_to_use/mix.lock
@@ -1,4 +1,8 @@
 %{
-  "exatomvm": {:git, "https://github.com/atomvm/ExAtomVM/", "cbd2fb6cb3b0c614c1973919a4f43c00f4495c33", []},
+  "cc_precompiler": {:hex, :cc_precompiler, "0.1.11", "8c844d0b9fb98a3edea067f94f616b3f6b29b959b6b3bf25fee94ffe34364768", [:mix], [{:elixir_make, "~> 0.7", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "3427232caf0835f94680e5bcf082408a70b48ad68a5f5c0b02a3bea9f3a075b9"},
+  "elixir_make": {:hex, :elixir_make, "0.9.0", "6484b3cd8c0cee58f09f05ecaf1a140a8c97670671a6a0e7ab4dc326c3109726", [:mix], [], "hexpm", "db23d4fd8b757462ad02f8aa73431a426fe6671c80b200d9710caf3d1dd0ffdb"},
+  "exatomvm": {:git, "https://github.com/atomvm/ExAtomVM/", "229151542a17190909be80704ed03bef32dbe324", []},
+  "fine": {:hex, :fine, "0.1.4", "b19a89c1476c7c57afb5f9314aed5960b5bc95d5277de4cb5ee8e1d1616ce379", [:mix], [], "hexpm", "be3324cc454a42d80951cf6023b9954e9ff27c6daa255483b3e8d608670303f5"},
+  "pythonx": {:hex, :pythonx, "0.4.7", "604a3a78377abdaa8739c561cb871c856b0e80d25fd057277839912017004af0", [:make, :mix], [{:cc_precompiler, "~> 0.1", [hex: :cc_precompiler, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.9", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:fine, "~> 0.1.2", [hex: :fine, repo: "hexpm", optional: false]}], "hexpm", "20d8b456df995e6ccd6d88dcf118ba80464194515f71a5c89aacdb824d235c52"},
   "uf2tool": {:hex, :uf2tool, "1.1.0", "7091931234ca5a256b66ea691983867d51229798622d083f85c1ad779798a734", [:rebar3], [], "hexpm", "1a7e5ca7ef3d19c7a0b0acf3db804b3188e0980884acffa13fd57d733507b73d"},
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an example project configuration so an existing dependency is not used at runtime (dev-only).
  * Added a new optional development dependency to the example; marked optional and not used at runtime so production behavior is unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->